### PR TITLE
Update init.lua

### DIFF
--- a/mods/ITEMS/vl_hollow_logs/init.lua
+++ b/mods/ITEMS/vl_hollow_logs/init.lua
@@ -62,6 +62,8 @@ function vl_hollow_logs.register_hollow_log(defs)
 		_mcl_blast_resistance = 2,
 		_mcl_hardness = 2,
 		_mcl_stripped_variant = modname .. ":stripped_"..name.."_hollow"
+		on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
+		end,
 	})
 
 	minetest.register_node(modname .. ":"..stripped_name.."_hollow", {


### PR DESCRIPTION
Deleted the bug with the Hollow logs. I just set the value on_rightclick on the fetching stems to an empty function.